### PR TITLE
Add a second context encoder

### DIFF
--- a/configs/transformer_wmt_chat.yaml
+++ b/configs/transformer_wmt_chat.yaml
@@ -1,0 +1,89 @@
+name: "my_experiment"
+
+data: # specify your data here
+    src: "en"                       # src language: expected suffix of train files, e.g. "train.de"
+    trg: "de"                       # trg language
+    train: "test/data/wmt/train"    # training data
+    dev: "test/data/wmt/dev"        # development data for validation
+    # test: "test/data/toy/test"      # test data for testing final model; optional
+    level: "bpe"                   # segmentation level: either "word", "bpe" or "char"
+    lowercase: True                 # lowercase the data, also for validation
+    max_sent_length: 30             # filter out longer sentences from training (src+trg)
+    src_voc_min_freq: 1             # src minimum frequency for a token to become part of the vocabulary
+    src_voc_limit: 101              # src vocabulary only includes this many most frequent tokens, default: unlimited
+    trg_voc_min_freq: 1             # trg minimum frequency for a token to become part of the vocabulary
+    trg_voc_limit: 102              # trg vocabulary only includes this many most frequent tokens, default: unlimited
+    #src_vocab: "my_model/src_vocab.txt"  # if specified, load a vocabulary from this file
+    #trg_vocab: "my_model/trg_vocab.txt"  # one token per line, line number is index
+
+testing:                            # specify which inference algorithm to use for testing (for validation it's always greedy decoding)
+    beam_size: 5                    # size of the beam for beam search
+    alpha: 1.0                      # length penalty for beam search
+
+training:                           # specify training details here
+    #load_model: "models/transformer/60.ckpt" # if given, load a pre-trained model from this checkpoint
+    reset_best_ckpt: False          # if True, reset the tracking of the best checkpoint and scores. Use for domain adaptation or fine-tuning with new metrics or dev data.
+    reset_scheduler: False          # if True, overwrite scheduler in loaded checkpoint with parameters specified in this config. Use for domain adaptation or fine-tuning.
+    reset_optimizer: False          # if True, overwrite optimizer in loaded checkpoint with parameters specified in this config. Use for domain adaptation or fine-tuning.
+    random_seed: 42                 # set this seed to make training deterministic
+    optimizer: "adam"               # choices: "sgd", "adam", "adadelta", "adagrad", "rmsprop", default is SGD
+    adam_betas: [0.9, 0.98]         # beta parameters for Adam. These are the defaults. Typically these are different for Transformer models.
+    learning_rate: 0.001            # initial learning rate, default: 3.0e-4
+    learning_rate_min: 0.000001     # stop learning when learning rate is reduced below this threshold, default: 1.0e-8
+    learning_rate_factor: 0.5       # factor for Noam scheduler (used with Transformer)
+    learning_rate_warmup: 1000      # warmup steps for Noam scheduler (used with Transformer)
+    #clip_grad_val: 1.0             # for Transformer do not clip (so leave commented out)
+    #clip_grad_norm: 1.0            # for Transformer do not clip (so leave commented out)
+    weight_decay: 0.                # l2 regularization, default: 0
+    batch_size: 250                 # mini-batch size as number of sentences (when batch_type is "sentence"; default) or total number of tokens (when batch_type is "token")
+    batch_type: "token"             # create batches with sentences ("sentence", default) or tokens ("token")
+    batch_multiplier: 1             # increase the effective batch size with values >1 to batch_multiplier*batch_size without increasing memory consumption by making updates only every batch_multiplier batches
+    normalization: "batch"          # loss normalization of a mini-batch, default: "batch" (by number of sequences in batch), other options: "tokens" (by number of tokens in batch), "none" (don't normalize, sum up loss)
+    scheduling: "noam"              # learning rate scheduling, optional, if not specified stays constant, options: "plateau", "exponential", "decaying", "noam" (for Transformer), "warmupexponentialdecay"
+    epochs: 10                      # train for this many epochs
+    validation_freq: 100            # validate after this many updates (number of mini-batches), default: 1000
+    logging_freq: 10                # log the training progress after this many updates, default: 100
+    eval_metric: "bleu"             # validation metric, default: "bleu", other options: "chrf", "token_accuracy", "sequence_accuracy"
+    early_stopping_metric: "loss"   # when a new high score on this metric is achieved, a checkpoint is written, when "eval_metric" (default) is maximized, when "loss" or "ppl" is minimized
+    model_dir: "models/transformer" # directory where models and validation results are stored, required
+    overwrite: True                 # overwrite existing model directory, default: False. Do not set to True unless for debugging!
+    shuffle: True                   # shuffle the training data, default: True
+    use_cuda: False                 # use CUDA for acceleration on GPU, required. Set to False when working on CPU.
+    max_output_length: 31           # maximum output length for decoding, default: None. If set to None, allow sentences of max 1.5*src length
+    print_valid_sents: [0, 1, 2]    # print this many validation sentences during each validation run, default: [0, 1, 2]
+    keep_last_ckpts: 3              # keep this many of the latest checkpoints, if -1: all of them, default: 5
+    label_smoothing: 0.0            # label smoothing: reference tokens will have 1-label_smoothing probability instead of 1, rest of probability mass is uniformly distributed over the rest of the vocabulary, default: 0.0 (off)
+
+model:                              # specify your model architecture here
+    initializer: "xavier"           # initializer for all trainable weights (xavier, zeros, normal, uniform)
+    init_gain: 1.0                  # gain for Xavier initializer (default: 1.0)
+    bias_initializer: "zeros"       # initializer for bias terms (xavier, zeros, normal, uniform)
+    embed_initializer: "xavier"     # initializer for embeddings (xavier, zeros, normal, uniform)
+    embed_init_gain: 1.0            # gain for Xavier initializer for embeddings (default: 1.0)
+    tied_embeddings: False          # tie src and trg embeddings, only applicable if vocabularies are the same, default: False
+    tied_softmax: True
+    encoder:
+        type: "transformer"          # encoder type: "recurrent" for LSTM or GRU, or "transformer" for a Transformer
+        num_layers: 3               # number of layers
+        num_heads: 4                # number of transformer heads
+        embeddings:
+            embedding_dim: 64       # size of embeddings (for Transformer set equal to hidden_size)
+            scale: True             # scale the embeddings by sqrt of their size, default: False
+            freeze: False           # if True, embeddings are not updated during training
+        hidden_size: 64             # size of hidden layer; must be divisible by number of heads
+        ff_size: 128                # size of position-wise feed-forward layer
+        dropout: 0.1                # apply dropout to the inputs to the RNN, default: 0.0
+        freeze: False               # if True, encoder parameters are not updated during training (does not include embedding parameters)
+        multi_encoder: True         # if True, add an encoder to parametrize context sentences
+    decoder:
+        type: "transformer"         # decoder type: "recurrent" for LSTM or GRU, or "transformer" for a Transformer
+        num_layers: 3               # number of layers
+        num_heads: 4                # number of transformer heads
+        embeddings:
+            embedding_dim: 64
+            scale: True
+            freeze: False           # if True, embeddings are not updated during training
+        hidden_size: 64             # size of hidden layer; must be divisible by number of heads
+        ff_size: 128                # size of position-wise feed-forward layer
+        dropout: 0.1
+        freeze: False               # if True, decoder parameters are not updated during training (does not include embedding parameters, but attention)

--- a/joeynmt/batch.py
+++ b/joeynmt/batch.py
@@ -23,6 +23,13 @@ class Batch:
         """
         self.src, self.src_lengths = torch_batch.src
         self.src_mask = (self.src != pad_index).unsqueeze(1)
+        self.src_prev, self.src_prev_lengths, self.src_prev_mask, self.trg_prev, self.trg_prev_mask = None, None, None, None, None
+        if hasattr(torch_batch, "src_prev"):
+            self.src_prev, self.src_prev_lengths = torch_batch.src_prev
+            self.src_prev_mask = (self.src_prev != pad_index).unsqueeze(1)
+            self.trg_prev = None
+            self.trg_prev_mask = None
+
         self.nseqs = self.src.size(0)
         self.trg_input = None
         self.trg = None
@@ -42,6 +49,14 @@ class Batch:
             self.trg_mask = (self.trg_input != pad_index).unsqueeze(1)
             self.ntokens = (self.trg != pad_index).data.sum().item()
 
+        if hasattr(torch_batch, "trg_prev"):
+            prev_trg, prev_trg_lengths = torch_batch.trg_prev
+            self.trg_prev_input = prev_trg[:, :-1]
+            self.trg_prev_lengths = prev_trg_lengths
+            self.trg_prev = prev_trg[:, 1:]
+            self.trg_prev_mask = (self.trg_prev_input != pad_index).unsqueeze(1)
+            self.ntokens_prev = (self.trg_prev != pad_index).data.sum().item()
+
         if use_cuda:
             self._make_cuda()
 
@@ -53,11 +68,14 @@ class Batch:
         """
         self.src = self.src.cuda()
         self.src_mask = self.src_mask.cuda()
-
         if self.trg_input is not None:
             self.trg_input = self.trg_input.cuda()
             self.trg = self.trg.cuda()
             self.trg_mask = self.trg_mask.cuda()
+        if self.trg_prev_input is not None:
+            self.trg_prev_input = self.trg_prev_input.cuda()
+            self.trg_prev = self.trg_prev.cuda()
+            self.trg_prev_mask = self.trg_prev_mask.cuda()
 
     def sort_by_src_lengths(self):
         """

--- a/joeynmt/data.py
+++ b/joeynmt/data.py
@@ -15,38 +15,7 @@ from torchtext.data import Dataset, Iterator, Field
 from joeynmt.constants import UNK_TOKEN, EOS_TOKEN, BOS_TOKEN, PAD_TOKEN, CONTEXT_TOKEN, CONTEXT_EOS_TOKEN
 from joeynmt.vocabulary import build_vocab, Vocabulary
 
-class ContextTranslationDataset(Dataset):
-    """ Defines a dataset for nmt context translation."""
-    @staticmethod
-    def sort_key(ex):
-        return len(ex.src)
 
-    def __init__(self, path: str, exts, fields, **kwargs) -> None:
-        """
-        Create a dataset given path and field.
-
-        :param path: Prefix of path to the data file
-        :param ext: Containing the extension to path for this language.
-        :param fields: Containing the fields that will be used for data.
-        :param kwargs: Passed to the constructor of data.Dataset.
-        """
-        if not isinstance(fields[0], (tuple, list)):
-            fields = [('src_prev', fields[0]), ('trg_prev', fields[1]), ('src', fields[2]), ('trg', fields[3])]
-        # fields = [('src', field)]
-        src_path, trg_path = tuple(os.path.expanduser(path + x) for x in exts)
-        examples = []
-
-        with io.open(src_path, mode='r', encoding='utf-8') as src_file, \
-                io.open(trg_path, mode='r', encoding='utf-8') as trg_file:
-            prev_src_line, prev_trg_line = CONTEXT_TOKEN + CONTEXT_EOS_TOKEN, CONTEXT_TOKEN + CONTEXT_EOS_TOKEN
-            for src_line, trg_line in zip(src_file, trg_file):
-                src_line, trg_line = src_line.strip(), trg_line.strip()
-                if src_line != '' and trg_line != '':
-                    examples.append(data.Example.fromlist(
-                        [prev_src_line, prev_trg_line, src_line, trg_line], fields))
-                    prev_src_line = src_line # Prepend special token, since src and context encoders share parameters
-                    prev_trg_line = trg_line
-        super(ContextTranslationDataset, self).__init__(examples, fields, **kwargs)
 
 def load_data(data_cfg: dict) -> (Dataset, Dataset, Optional[Dataset],
                                   Vocabulary, Vocabulary):
@@ -299,3 +268,36 @@ class MonoDataset(Dataset):
         src_file.close()
 
         super(MonoDataset, self).__init__(examples, fields, **kwargs)
+
+class ContextTranslationDataset(Dataset):
+    """ Defines a dataset for nmt context translation."""
+    @staticmethod
+    def sort_key(ex):
+        return len(ex.src)
+
+    def __init__(self, path: str, exts, fields, **kwargs) -> None:
+        """
+        Create a dataset given path and field.
+
+        :param path: Prefix of path to the data file
+        :param ext: Containing the extension to path for this language.
+        :param fields: Containing the fields that will be used for data.
+        :param kwargs: Passed to the constructor of data.Dataset.
+        """
+        if not isinstance(fields[0], (tuple, list)):
+            fields = [('src_prev', fields[0]), ('trg_prev', fields[1]), ('src', fields[2]), ('trg', fields[3])]
+        # fields = [('src', field)]
+        src_path, trg_path = tuple(os.path.expanduser(path + x) for x in exts)
+        examples = []
+
+        with io.open(src_path, mode='r', encoding='utf-8') as src_file, \
+                io.open(trg_path, mode='r', encoding='utf-8') as trg_file:
+            prev_src_line, prev_trg_line = CONTEXT_TOKEN + CONTEXT_EOS_TOKEN, CONTEXT_TOKEN + CONTEXT_EOS_TOKEN
+            for src_line, trg_line in zip(src_file, trg_file):
+                src_line, trg_line = src_line.strip(), trg_line.strip()
+                if src_line != '' and trg_line != '':
+                    examples.append(data.Example.fromlist(
+                        [prev_src_line, prev_trg_line, src_line, trg_line], fields))
+                    prev_src_line = src_line # Prepend special token, since src and context encoders share parameters
+                    prev_trg_line = trg_line
+        super(ContextTranslationDataset, self).__init__(examples, fields, **kwargs)

--- a/joeynmt/encoders.py
+++ b/joeynmt/encoders.py
@@ -160,6 +160,7 @@ class TransformerEncoder(Encoder):
                  dropout: float = 0.1,
                  emb_dropout: float = 0.1,
                  freeze: bool = False,
+                 dont_minus_one: bool = True,
                  **kwargs):
         """
         Initializes the Transformer.
@@ -179,8 +180,8 @@ class TransformerEncoder(Encoder):
         self.layers = nn.ModuleList([
             TransformerEncoderLayer(size=hidden_size, ff_size=ff_size,
                                     num_heads=num_heads, dropout=dropout)
-            for _ in range(num_layers)])
-
+            for _ in range(num_layers if dont_minus_one else num_layers-1)])
+        self.top_off = False if dont_minus_one else True
         self.layer_norm = nn.LayerNorm(hidden_size, eps=1e-6)
         self.pe = PositionalEncoding(hidden_size)
         self.emb_dropout = nn.Dropout(p=emb_dropout)
@@ -218,7 +219,10 @@ class TransformerEncoder(Encoder):
 
         for layer in self.layers:
             x = layer(x, mask)
-        return self.layer_norm(x), None
+        if self.top_off:
+            return x, None
+        else:
+            return self.layer_norm(x), None
 
     def __repr__(self):
         return "%s(num_layers=%r, num_heads=%r)" % (

--- a/joeynmt/training.py
+++ b/joeynmt/training.py
@@ -19,7 +19,7 @@ from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
 from torchtext.data import Dataset
-
+import torchtext
 from joeynmt.model import build_model
 from joeynmt.batch import Batch
 from joeynmt.helpers import log_data_info, load_config, log_cfg, \
@@ -275,6 +275,7 @@ class TrainManager:
         :param train_data: training data
         :param valid_data: validation data
         """
+
         train_iter = make_data_iter(train_data,
                                     batch_size=self.batch_size,
                                     batch_type=self.batch_type,
@@ -305,6 +306,7 @@ class TrainManager:
                 # reactivate training
                 self.model.train()
                 # create a Batch object from torchtext batch
+                # print("batch is {}")
                 batch = Batch(batch, self.pad_index, use_cuda=self.use_cuda)
 
                 # only update every batch_multiplier batches
@@ -647,6 +649,8 @@ def train(cfg_file: str) -> None:
     trg_vocab.to_file(trg_vocab_file)
 
     # train the model
+    # Modify train_data here..
+
     trainer.train_and_validate(train_data=train_data, valid_data=dev_data)
 
     # predict with the best model on validation and test


### PR DESCRIPTION
Prepare for the encoding of 1 previous context utterances by setting up requisite infrastructure in model architecture.

Still need to implement the combination function, https://github.com/SongChujun/joeynmt/blob/6b3c69c/joeynmt/transformer_layers.py#L182

Currently, it is only returning the source context and continuing as normal. We need to somehow work the context encoding into this function.